### PR TITLE
fb: address fb on nesting dependency groups

### DIFF
--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -355,7 +355,17 @@ class Factory:
                     current_group = package.dependency_group(group_name)
                     for name in include_groups:
                         try:
-                            group_to_include = package.dependency_group(name)
+                            # Neither the current name nor the package's
+                            # dependency group names are guaranteed to be
+                            # normalized. Compare the normalized names to find
+                            # the actual key to use.
+                            all_group_names = package.dependency_group_names()
+                            group_name_to_use = next(
+                                (n
+                                for n in all_group_names
+                                if canonicalize_name(n) == canonicalize_name(name)))
+
+                            group_to_include = package.dependency_group(group_name_to_use)
                         except ValueError as e:
                             raise ValueError(
                                 f"Group '{group_name}' includes group '{name}'"

--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -655,7 +655,7 @@ class Factory:
                 ]
 
         for group_name in group_includes:
-            ancestors = defaultdict(set[NormalizedName])
+            ancestors: defaultdict[NormalizedName, set[NormalizedName]] = defaultdict(set)
             stack = [group_name]
             while stack:
                 group = stack.pop()

--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -669,9 +669,12 @@ class Factory:
                         # Avoid infinite loop; we've already found an error.
                         continue
                     
-                    # TODO: test this scenario
+                    # This must be a union with any existing known ancestors.
+                    # Otherwise, we might accidentally miss a cycle (since we'd
+                    # be tossing out known dependencies). That cycle will be
+                    # caught when we use the share dependency as `group_name`,
+                    # but best to be safe.
                     ancestors[include] = ancestors.get(include, set()).union(child_ancestors)
-                    # ancestors[include] = child_ancestors
                     stack.append(include)
 
     @classmethod

--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -647,7 +647,7 @@ class Factory:
         """Ensure that dependency groups do not include themselves."""
         config = toml_data.setdefault("tool", {}).setdefault("poetry", {})
 
-        group_includes = {}
+        group_includes: dict[NormalizedName, list[NormalizedName]] = {}
         for group_name, group_config in config.get("group", {}).items():
             if include_groups := group_config.get("include-groups", []):
                 group_includes[canonicalize_name(group_name)] = [
@@ -655,7 +655,7 @@ class Factory:
                 ]
 
         for group_name in group_includes:
-            ancestors = defaultdict(set[str])
+            ancestors = defaultdict(set[NormalizedName])
             stack = [group_name]
             while stack:
                 group = stack.pop()

--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -371,6 +371,11 @@ class Factory:
                                 f"Group '{group_name}' includes group '{name}'"
                                 " which is not defined."
                             ) from e
+                        except StopIteration as e:
+                            raise ValueError(
+                                f"Group '{group_name}' includes group '{name}'"
+                                " which is not defined."
+                            ) from e
 
                         current_group.include_dependency_group(group_to_include)
 

--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -657,14 +657,11 @@ class Factory:
             stack = [group_name]
             while stack:
                 group = stack.pop()
-
-                canon_group = canonicalize_name(group)
-                current_ancestors = ancestors.get(canon_group, set())
-                child_ancestors = current_ancestors.union({canon_group})
+                current_ancestors = ancestors.get(group, set())
+                child_ancestors = current_ancestors.union({group})
 
                 for include in group_includes.get(group, []):
-                    canon_include = canonicalize_name(include)
-                    if canon_include in child_ancestors:
+                    if include in child_ancestors:
                         result["errors"].append(
                             f"Cyclic dependency group include in {group_name}:"
                             f" {group} -> {include}"
@@ -672,7 +669,9 @@ class Factory:
                         # Avoid infinite loop; we've already found an error.
                         continue
                     
-                    ancestors[canon_include] = child_ancestors
+                    # TODO: test this scenario
+                    ancestors[include] = ancestors.get(include, set()).union(child_ancestors)
+                    # ancestors[include] = child_ancestors
                     stack.append(include)
 
     @classmethod

--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -355,23 +355,10 @@ class Factory:
                     current_group = package.dependency_group(group_name)
                     for name in include_groups:
                         try:
-                            # Neither the current name nor the package's
-                            # dependency group names are guaranteed to be
-                            # normalized. Compare the normalized names to find
-                            # the actual key to use.
-                            all_group_names = package.dependency_group_names()
-                            group_name_to_use = next(
-                                (n
-                                for n in all_group_names
-                                if canonicalize_name(n) == canonicalize_name(name)))
-
-                            group_to_include = package.dependency_group(group_name_to_use)
+                            # `name` isn't normalized, but `.dependency_group()`
+                            # handles that.
+                            group_to_include = package.dependency_group(name)
                         except ValueError as e:
-                            raise ValueError(
-                                f"Group '{group_name}' includes group '{name}'"
-                                " which is not defined."
-                            ) from e
-                        except StopIteration as e:
                             raise ValueError(
                                 f"Group '{group_name}' includes group '{name}'"
                                 " which is not defined."

--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -347,7 +347,7 @@ class Factory:
                 cls._add_package_group_dependencies(
                     package=package,
                     group=group,
-                    dependencies=group_config["dependencies"],
+                    dependencies=group_config.get("dependencies", {}),
                 )
 
             for group_name, group_config in tool_poetry["group"].items():

--- a/src/poetry/core/json/schemas/poetry-schema.json
+++ b/src/poetry/core/json/schemas/poetry-schema.json
@@ -171,8 +171,17 @@
         "^[a-zA-Z-_.0-9]+$": {
           "type": "object",
           "description": "This represents a single dependency group",
-          "required": [
-            "dependencies"
+          "anyOf": [
+            {
+              "required": [
+                "dependencies"
+              ]
+            },
+            {
+              "required": [
+                "include-groups"
+              ]
+            }
           ],
           "properties": {
             "optional": {

--- a/src/poetry/core/json/schemas/poetry-schema.json
+++ b/src/poetry/core/json/schemas/poetry-schema.json
@@ -179,6 +179,13 @@
               "type": "boolean",
               "description": "Whether the dependency group is optional or not"
             },
+            "include-groups": {
+              "type": "array",
+              "description": "List of dependency group names included in this group.",
+              "items": {
+                "type": "string"
+              }
+            },
             "dependencies": {
               "type": "object",
               "description": "The dependencies of this dependency group",

--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -73,7 +73,7 @@ class Dependency(PackageSpecification):
         if not groups:
             groups = [MAIN_GROUP]
 
-        self._groups = frozenset(canonicalize_name(g) for g in groups)
+        self.groups = frozenset(canonicalize_name(g) for g in groups)
         self._allows_prereleases = allows_prereleases
         # "_develop" is only required for enriching [project] dependencies
         self._develop = False
@@ -114,10 +114,6 @@ class Dependency(PackageSpecification):
     @property
     def pretty_name(self) -> str:
         return self._pretty_name
-
-    @property
-    def groups(self) -> frozenset[NormalizedName]:
-        return self._groups
 
     @property
     def python_versions(self) -> str:
@@ -330,6 +326,11 @@ class Dependency(PackageSpecification):
     def with_constraint(self: T, constraint: str | VersionConstraint) -> T:
         dependency = self.clone()
         dependency.constraint = constraint  # type: ignore[assignment]
+        return dependency
+
+    def with_groups(self, groups: Iterable[str]) -> Dependency:
+        dependency = self.clone()
+        dependency.groups = frozenset(canonicalize_name(g) for g in groups)
         return dependency
 
     @classmethod

--- a/src/poetry/core/packages/dependency_group.py
+++ b/src/poetry/core/packages/dependency_group.py
@@ -39,7 +39,7 @@ class DependencyGroup:
     @property
     def dependencies(self) -> list[Dependency]:
         group_dependencies = self._dependencies
-        included_group_dependencies = self._resolve_included_dependency_groups()
+        included_group_dependencies = self._resolve_included_dependency_groups(dependencies_for_locking=False)
 
         if not group_dependencies:
             # legacy mode
@@ -60,7 +60,7 @@ class DependencyGroup:
 
     @property
     def dependencies_for_locking(self) -> list[Dependency]:
-        included_group_dependencies = self._resolve_included_dependency_groups()
+        included_group_dependencies = self._resolve_included_dependency_groups(dependencies_for_locking=True)
 
         if not self._poetry_dependencies:
             dependencies = self._dependencies
@@ -100,7 +100,7 @@ class DependencyGroup:
 
         return dependencies + included_group_dependencies
 
-    def _resolve_included_dependency_groups(self) -> list[Dependency]:
+    def _resolve_included_dependency_groups(self, dependencies_for_locking: bool = False) -> list[Dependency]:
         """Resolves and returns the dependencies from included dependency groups.
 
         This method iterates over all included dependency groups and collects
@@ -109,7 +109,7 @@ class DependencyGroup:
         return [
             dependency.with_groups([self.name])
             for dependency_group in self._included_dependency_groups.values()
-            for dependency in dependency_group.dependencies
+            for dependency in (dependency_group.dependencies_for_locking if dependencies_for_locking else dependency_group.dependencies)
         ]
 
     def is_optional(self) -> bool:

--- a/src/poetry/core/packages/dependency_group.py
+++ b/src/poetry/core/packages/dependency_group.py
@@ -107,7 +107,7 @@ class DependencyGroup:
         their dependencies, associating them with the current group.
         """
         return [
-            dependency.with_groups([self.name])
+            dependency.with_groups([canonicalize_name(self.name)])
             for dependency_group in self._included_dependency_groups.values()
             for dependency in dependency_group.dependencies
         ]

--- a/src/poetry/core/packages/dependency_group.py
+++ b/src/poetry/core/packages/dependency_group.py
@@ -107,7 +107,7 @@ class DependencyGroup:
         their dependencies, associating them with the current group.
         """
         return [
-            dependency.with_groups([canonicalize_name(self.name)])
+            dependency.with_groups([self.name])
             for dependency_group in self._included_dependency_groups.values()
             for dependency in dependency_group.dependencies
         ]

--- a/tests/packages/test_dependency_group.py
+++ b/tests/packages/test_dependency_group.py
@@ -557,10 +557,24 @@ def test_include_dependency_groups() -> None:
         Dependency(name="bar", constraint="*", groups=["group2"])
     )
 
-    group.include_dependency_group(group_2)
+    # This will resolve to a more precise constraint in dependencies_for_locking.
+    group_3 = DependencyGroup(name="group3")
+    group_3._dependencies = [
+        Dependency(name="baz", constraint="<2", groups=["group3"])
+    ]
+    group_3._poetry_dependencies = [
+        Dependency(name="baz", constraint=">=1", groups=["group3"])
+    ]
 
-    assert [dep.name for dep in group.dependencies] == ["foo", "bar"]
-    assert [dep.name for dep in group.dependencies_for_locking] == ["foo", "bar"]
+    group.include_dependency_group(group_2)
+    group.include_dependency_group(group_3)
+
+    assert [dep.name for dep in group.dependencies] == ["foo", "bar", "baz"]
+    assert [dep.name for dep in group.dependencies_for_locking] == ["foo", "bar", "baz"]
+    assert [dep.pretty_constraint for dep in group.dependencies] == ["*", "*", "<2"]
+    assert [dep.pretty_constraint for dep in group.dependencies_for_locking] == [
+        "*", "*", ">=1,<2"
+    ]
     for dep in group.dependencies:
         assert dep.groups == {"group"}
 
@@ -568,6 +582,13 @@ def test_include_dependency_groups() -> None:
     assert [dep.name for dep in group_2.dependencies_for_locking] == ["bar"]
     for dep in group_2.dependencies:
         assert dep.groups == {"group2"}
+
+    assert [dep.name for dep in group_3.dependencies] == ["baz"]
+    assert [dep.name for dep in group_3.dependencies_for_locking] == ["baz"]
+    assert [dep.pretty_constraint for dep in group_3.dependencies] == ["<2"]
+    assert [dep.pretty_constraint for dep in group_3.dependencies_for_locking] == [">=1,<2"]
+    for dep in group_3.dependencies:
+        assert dep.groups == {"group3"}
 
 
 @pytest.mark.parametrize("group_name", ["group_2", "Group-2", "group-2"])

--- a/tests/packages/test_dependency_group.py
+++ b/tests/packages/test_dependency_group.py
@@ -544,3 +544,65 @@ def test_dependency_group_use_canonicalize_name(
     group = DependencyGroup(pretty_name)
     assert group.name == canonicalized_name
     assert group.pretty_name == pretty_name
+
+
+def test_include_dependency_groups() -> None:
+    group = DependencyGroup(name="group")
+    group.add_poetry_dependency(
+        Dependency(name="foo", constraint="*", groups=["group"])
+    )
+
+    group_2 = DependencyGroup(name="group2")
+    group_2.add_poetry_dependency(
+        Dependency(name="bar", constraint="*", groups=["group2"])
+    )
+
+    group.include_dependency_group(group_2)
+
+    assert [dep.name for dep in group.dependencies] == ["foo", "bar"]
+    assert [dep.name for dep in group.dependencies_for_locking] == ["foo", "bar"]
+    for dep in group.dependencies:
+        assert dep.groups == {"group"}
+
+    assert [dep.name for dep in group_2.dependencies] == ["bar"]
+    assert [dep.name for dep in group_2.dependencies_for_locking] == ["bar"]
+    for dep in group_2.dependencies:
+        assert dep.groups == {"group2"}
+
+
+@pytest.mark.parametrize("group_name", ["group_2", "Group-2", "group-2"])
+def test_include_dependency_group_raise_if_including_itself(group_name: str) -> None:
+    group = DependencyGroup(name="group-2")
+    group.add_poetry_dependency(
+        Dependency(name="foo", constraint="*", groups=["group"])
+    )
+
+    with pytest.raises(
+        ValueError, match="Cannot include the dependency group to itself"
+    ):
+        group.include_dependency_group(DependencyGroup(name=group_name))
+
+
+@pytest.mark.parametrize("group_name", ["group_2", "Group-2", "group-2"])
+def test_include_dependency_group_raise_if_already_included(group_name: str) -> None:
+    group = DependencyGroup(name="group")
+    group.add_poetry_dependency(
+        Dependency(name="foo", constraint="*", groups=["group"])
+    )
+
+    group_2 = DependencyGroup(name="group_2")
+    group_2.add_poetry_dependency(
+        Dependency(name="bar", constraint="*", groups=["group2"])
+    )
+
+    group.include_dependency_group(group_2)
+
+    group_3 = DependencyGroup(name=group_name)
+    group_3.add_poetry_dependency(
+        Dependency(name="bar", constraint="*", groups=["group2"])
+    )
+
+    with pytest.raises(
+        ValueError, match=f"Dependency group {group_name} is already included"
+    ):
+        group.include_dependency_group(group_3)

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1307,3 +1307,36 @@ black = "*"
         error_type=ValueError,
         temporary_directory=temporary_directory,
     )
+
+
+def test_create_poetry_with_included_groups_only(temporary_directory: Path) -> None:
+    pyproject_toml = temporary_directory / "pyproject.toml"
+    content = """\
+[project]
+name = "my-package"
+version = "1.2.3"
+
+[tool.poetry.group.lint.dependencies]
+black = "*"
+
+[tool.poetry.group.testing.dependencies]
+pytest = "*"
+
+[tool.poetry.group.all]
+include-groups = [
+    "lint",
+    "testing",
+]
+"""
+    pyproject_toml.write_text(content)
+
+    poetry = Factory().create_poetry(temporary_directory)
+    assert len(poetry.package.all_requires) == 4
+    assert [
+        (dep.name, ",".join(dep.groups)) for dep in poetry.package.all_requires
+    ] == [
+        ("black", "lint"),
+        ("pytest", "testing"),
+        ("black", "all"),
+        ("pytest", "all"),
+    ]

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1149,6 +1149,9 @@ pytest-cov ="*"
     pyproject_toml.write_text(content)
     poetry = Factory().create_poetry(temporary_directory)
 
+    # Groups are reported internally using their canonical names.
+    canonical_name = canonicalize_name(group_name)
+
     assert len(poetry.package.all_requires) == 5
     assert sorted(
         [(dep.name, ",".join(dep.groups)) for dep in poetry.package.all_requires],
@@ -1156,9 +1159,9 @@ pytest-cov ="*"
     ) == sorted([
         ("black", "dev"),
         ("pytest-cov", "dev"),
-        ("pytest-cov", group_name),
+        ("pytest-cov", canonical_name),
         ("pytest", "dev"),
-        ("pytest", group_name),
+        ("pytest", canonical_name),
     ], key = lambda x: x[0] + x[1])
 
 
@@ -1381,13 +1384,13 @@ quux = "*"
         [(dep.name, ",".join(dep.groups)) for dep in poetry.package.all_requires],
         key = lambda x: x[0] + x[1],
     ) == [
-        ("bar", "child_1"),
+        ("bar", "child-1"),
         ("bar", "root"),
-        ("baz", "child_2"),
+        ("baz", "child-2"),
         ("baz", "root"),
         ("foo", "root"),
-        ("quux", "child_1"),
-        ("quux", "child_2"),
+        ("quux", "child-1"),
+        ("quux", "child-2"),
         ("quux", "root"),
         ("quux", "root"), # TODO: is this expected?
         ("quux", "shared"),
@@ -1443,16 +1446,16 @@ quux = "*"
         [(dep.name, ",".join(dep.groups)) for dep in poetry.package.all_requires],
         key = lambda x: x[0] + x[1],
     ) == [
-        ("bar", "child_1"),
+        ("bar", "child-1"),
         ("bar", "root"),
-        ("bax", "child_2"),
+        ("bax", "child-2"),
         ("bax", "grandchild"),
         ("bax", "root"),
-        ("baz", "child_2"),
+        ("baz", "child-2"),
         ("baz", "root"),
         ("foo", "root"),
-        ("quux", "child_1"),
-        ("quux", "child_2"),
+        ("quux", "child-1"),
+        ("quux", "child-2"),
         ("quux", "grandchild"),
         ("quux", "root"),
         ("quux", "root"), # TODO: is this expected?

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1471,7 +1471,7 @@ quux = "*"
 
 [tool.poetry.group.grandchild]
 include-groups = [
-    "child_1",
+    "child_2",
 ]
 [tool.poetry.group.grandchild.dependencies]
 bar = "*"
@@ -1479,11 +1479,11 @@ bar = "*"
 
     expected = """\
 The Poetry configuration is invalid:
-  - Cyclic dependency group include in root: child-1 -> shared
-  - Cyclic dependency group include in root: child-1 -> shared
-  - Cyclic dependency group include in child-1: grandchild -> child-1
-  - Cyclic dependency group include in child-2: child-1 -> shared
-  - Cyclic dependency group include in shared: child-1 -> shared
+  - Cyclic dependency group include in root: grandchild -> child-2
+  - Cyclic dependency group include in root: grandchild -> child-2
+  - Cyclic dependency group include in child-1: child-2 -> shared
+  - Cyclic dependency group include in child-2: grandchild -> child-2
+  - Cyclic dependency group include in shared: child-2 -> shared
   - Cyclic dependency group include in grandchild: shared -> grandchild
 """
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1077,8 +1077,35 @@ build-backend = "some.api.we.do.not.care.about"
 @pytest.mark.parametrize(
     ("group_name", "included_group_name", "in_order"),
     [
-       ("testing", "testing", True),
-       ("testing", "testing", False) 
+        ("testing", "testing", True),
+        ("testing", "testing", False),
+        ("testing", "TESTING", True),
+        ("testing", "TESTING", False),
+        ("group_a", "group-a", True),
+        ("group_a", "group-a", False),
+
+        # https://packaging.python.org/en/latest/specifications/name-normalization/#valid-non-normalized-names
+        # friendly-bard
+        # Friendly-Bard
+        # FRIENDLY-BARD
+        # friendly.bard
+        # friendly_bard
+        # friendly--bard
+        # FrIeNdLy-._.-bArD
+        ("friendly-bard", "friendly-bard", True),
+        ("friendly-bard", "friendly-bard", False),
+        ("friendly-bard", "Friendly-Bard", True),
+        ("friendly-bard", "Friendly-Bard", False),
+        ("friendly-bard", "FRIENDLY-BARD", True),
+        ("friendly-bard", "FRIENDLY-BARD", False),
+        ("friendly-bard", "friendly.bard", True),
+        ("friendly-bard", "friendly.bard", False),
+        ("friendly-bard", "friendly_bard", True),
+        ("friendly-bard", "friendly_bard", False),
+        ("friendly-bard", "friendly--bard", True),
+        ("friendly-bard", "friendly--bard", False),
+        ("friendly-bard", "FrIeNdLy-._.-bArD", True),
+        ("friendly-bard", "FrIeNdLy-._.-bArD", False),
     ])
 def test_create_poetry_with_nested_dependency_groups(group_name: str, included_group_name: str, in_order: bool, temporary_directory: Path) -> None:
     pyproject_toml = temporary_directory / "pyproject.toml"
@@ -1130,9 +1157,9 @@ pytest-cov ="*"
     ) == [
         ("black", "dev"),
         ("pytest-cov", "dev"),
-        ("pytest-cov", "testing"),
+        ("pytest-cov", canonicalize_name(group_name)),
         ("pytest", "dev"),
-        ("pytest", "testing"),
+        ("pytest", canonicalize_name(group_name)),
     ]
 
 
@@ -1355,13 +1382,13 @@ quux = "*"
         [(dep.name, ",".join(dep.groups)) for dep in poetry.package.all_requires],
         key = lambda x: x[0] + x[1],
     ) == [
-        ("bar", "child_1"),
+        ("bar", "child-1"),
         ("bar", "root"),
-        ("baz", "child_2"),
+        ("baz", "child-2"),
         ("baz", "root"),
         ("foo", "root"),
-        ("quux", "child_1"),
-        ("quux", "child_2"),
+        ("quux", "child-1"),
+        ("quux", "child-2"),
         ("quux", "root"),
         ("quux", "root"), # TODO: is this expected?
         ("quux", "shared"),
@@ -1417,16 +1444,16 @@ quux = "*"
         [(dep.name, ",".join(dep.groups)) for dep in poetry.package.all_requires],
         key = lambda x: x[0] + x[1],
     ) == [
-        ("bar", "child_1"),
+        ("bar", "child-1"),
         ("bar", "root"),
-        ("bax", "child_2"),
+        ("bax", "child-2"),
         ("bax", "grandchild"),
         ("bax", "root"),
-        ("baz", "child_2"),
+        ("baz", "child-2"),
         ("baz", "root"),
         ("foo", "root"),
-        ("quux", "child_1"),
-        ("quux", "child_2"),
+        ("quux", "child-1"),
+        ("quux", "child-2"),
         ("quux", "grandchild"),
         ("quux", "root"),
         ("quux", "root"), # TODO: is this expected?

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1106,6 +1106,22 @@ build-backend = "some.api.we.do.not.care.about"
         ("friendly-bard", "friendly--bard", False),
         ("friendly-bard", "FrIeNdLy-._.-bArD", True),
         ("friendly-bard", "FrIeNdLy-._.-bArD", False),
+
+        ("friendly-bard", "friendly-bard", True),
+        ("friendly-bard", "friendly-bard", False),
+        ("friendly-Bard", "friendly-bard", True),
+        ("friendly-Bard", "friendly-bard", False),
+        ("FRIENDLY-BARD", "friendly-bard", True),
+        ("FRIENDLY-BARD", "friendly-bard", False),
+        # ("friendly.bard", "friendly-bard", True),
+        # ("friendly.bard", "friendly-bard", False),
+        ("friendly_bard", "friendly-bard", True),
+        ("friendly_bard", "friendly-bard", False),
+        ("friendly--bard", "friendly-bard", True),
+        ("friendly--bard", "friendly-bard", False),
+        # ("FrIeNdLy-._.-bArD", "friendly-bard", True),
+        # ("FrIeNdLy-._.-bArD", "friendly-bard", False),
+
     ])
 def test_create_poetry_with_nested_dependency_groups(group_name: str, included_group_name: str, in_order: bool, temporary_directory: Path) -> None:
     pyproject_toml = temporary_directory / "pyproject.toml"
@@ -1154,13 +1170,13 @@ pytest-cov ="*"
     assert sorted(
         [(dep.name, ",".join(dep.groups)) for dep in poetry.package.all_requires],
         key = lambda x: x[0] + x[1],
-    ) == [
+    ) == sorted([
         ("black", "dev"),
         ("pytest-cov", "dev"),
-        ("pytest-cov", canonicalize_name(group_name)),
+        ("pytest-cov", group_name),
         ("pytest", "dev"),
-        ("pytest", canonicalize_name(group_name)),
-    ]
+        ("pytest", group_name),
+    ], key = lambda x: x[0] + x[1])
 
 
 def assert_invalid_group_including(
@@ -1382,13 +1398,13 @@ quux = "*"
         [(dep.name, ",".join(dep.groups)) for dep in poetry.package.all_requires],
         key = lambda x: x[0] + x[1],
     ) == [
-        ("bar", "child-1"),
+        ("bar", "child_1"),
         ("bar", "root"),
-        ("baz", "child-2"),
+        ("baz", "child_2"),
         ("baz", "root"),
         ("foo", "root"),
-        ("quux", "child-1"),
-        ("quux", "child-2"),
+        ("quux", "child_1"),
+        ("quux", "child_2"),
         ("quux", "root"),
         ("quux", "root"), # TODO: is this expected?
         ("quux", "shared"),
@@ -1444,16 +1460,16 @@ quux = "*"
         [(dep.name, ",".join(dep.groups)) for dep in poetry.package.all_requires],
         key = lambda x: x[0] + x[1],
     ) == [
-        ("bar", "child-1"),
+        ("bar", "child_1"),
         ("bar", "root"),
-        ("bax", "child-2"),
+        ("bax", "child_2"),
         ("bax", "grandchild"),
         ("bax", "root"),
-        ("baz", "child-2"),
+        ("baz", "child_2"),
         ("baz", "root"),
         ("foo", "root"),
-        ("quux", "child-1"),
-        ("quux", "child-2"),
+        ("quux", "child_1"),
+        ("quux", "child_2"),
         ("quux", "grandchild"),
         ("quux", "root"),
         ("quux", "root"), # TODO: is this expected?

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1096,6 +1096,7 @@ black = "*"
 """
         ),
         (
+            # Ensure that we can reference groups that are defined later.
             """\
 [project]
 name = "my-package"

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1073,49 +1073,32 @@ build-backend = "some.api.we.do.not.care.about"
 
     assert set(poetry.build_system_dependencies) == expected
 
-
+@pytest.mark.parametrize("in_order", [True, False])
 @pytest.mark.parametrize(
-    ("group_name", "included_group_name", "in_order"),
+    ("group_name", "included_group_name"),
     [
-        ("testing", "testing", True),
-        ("testing", "testing", False),
-        ("testing", "TESTING", True),
-        ("testing", "TESTING", False),
-        ("group_a", "group-a", True),
-        ("group_a", "group-a", False),
+        ("testing", "testing"),
+        ("testing", "TESTING"),
+        ("group_a", "group-a"),
 
         # Examples from the PEP 508 spec
         # https://packaging.python.org/en/latest/specifications/name-normalization/#valid-non-normalized-names
-        ("friendly-bard", "friendly-bard", True),
-        ("friendly-bard", "friendly-bard", False),
-        ("friendly-bard", "Friendly-Bard", True),
-        ("friendly-bard", "Friendly-Bard", False),
-        ("friendly-bard", "FRIENDLY-BARD", True),
-        ("friendly-bard", "FRIENDLY-BARD", False),
-        ("friendly-bard", "friendly.bard", True),
-        ("friendly-bard", "friendly.bard", False),
-        ("friendly-bard", "friendly_bard", True),
-        ("friendly-bard", "friendly_bard", False),
-        ("friendly-bard", "friendly--bard", True),
-        ("friendly-bard", "friendly--bard", False),
-        ("friendly-bard", "FrIeNdLy-._.-bArD", True),
-        ("friendly-bard", "FrIeNdLy-._.-bArD", False),
+        ("friendly-bard", "friendly-bard"),
+        ("friendly-bard", "Friendly-Bard"),
+        ("friendly-bard", "FRIENDLY-BARD"),
+        ("friendly-bard", "friendly.bard"),
+        ("friendly-bard", "friendly_bard"),
+        ("friendly-bard", "friendly--bard"),
+        ("friendly-bard", "FrIeNdLy-._.-bArD"),
 
-        ("friendly-bard", "friendly-bard", True),
-        ("friendly-bard", "friendly-bard", False),
-        ("friendly-Bard", "friendly-bard", True),
-        ("friendly-Bard", "friendly-bard", False),
-        ("FRIENDLY-BARD", "friendly-bard", True),
-        ("FRIENDLY-BARD", "friendly-bard", False),
-        ("friendly.bard", "friendly-bard", True),
-        ("friendly.bard", "friendly-bard", False),
-        ("friendly_bard", "friendly-bard", True),
-        ("friendly_bard", "friendly-bard", False),
-        ("friendly--bard", "friendly-bard", True),
-        ("friendly--bard", "friendly-bard", False),
-        ("FrIeNdLy-._.-bArD", "friendly-bard", True),
-        ("FrIeNdLy-._.-bArD", "friendly-bard", False),
-    ])
+        ("friendly-Bard", "friendly-bard"),
+        ("FRIENDLY-BARD", "friendly-bard"),
+        ("friendly.bard", "friendly-bard"),
+        ("friendly_bard", "friendly-bard"),
+        ("friendly--bard", "friendly-bard"),
+        ("FrIeNdLy-._.-bArD", "friendly-bard"),
+    ]
+)
 def test_create_poetry_with_nested_dependency_groups(group_name: str, included_group_name: str, in_order: bool, temporary_directory: Path) -> None:
     pyproject_toml = temporary_directory / "pyproject.toml"
 


### PR DESCRIPTION
Today, there is some open feedback on #837. This change addresses a lot of it, e.g. rewriting the cycle-detection algorithm & the name-deduping algorithm.

## What changed?

* Rewrote the cycle-detection algorithm to handle "diamond dependencies" better.
* Added additional tests for that case.
* Properly handle non-normalized groups (both when specified & included).
* Added additional tests for that case.

## How tested?

* [x] New tests pass.
* [x] Existing tests pass.